### PR TITLE
[backspace] Fix broken backspace behavior

### DIFF
--- a/src/parse-keypress.ts
+++ b/src/parse-keypress.ts
@@ -182,9 +182,8 @@ const parseKeypress = (s: Buffer | string = ''): ParsedKey => {
 		key.name = 'backspace';
 		key.meta = s.charAt(0) === '\x1b';
 	} else if (s === '\x7f' || s === '\x1b\x7f') {
-		// TODO(vadimdemedes): `enquirer` detects delete key as backspace, but I had to split them up to avoid breaking changes in Ink. Merge them back together in the next major version.
-		// delete
-		key.name = 'delete';
+		// ink incorrectly sends "delete" here. we changed this in our fork
+		key.name = 'backspace';
 		key.meta = s.charAt(0) === '\x1b';
 	} else if (s === '\x1b' || s === '\x1b\x1b') {
 		// escape key


### PR DESCRIPTION
The comment here is confusing, but changing this appears to fix the behavior of the backspace key on mac