### PR TITLE
Fix for two bugs in ink

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -192,11 +192,14 @@ export default class Ink {
 			if (this.options.onFlicker) {
 				this.options.onFlicker();
 			}
+			// We add an extra newline to match what logOutput does
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output,
+				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
 			);
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;
+			// Account for the extra newline
+			this.log.updateLineCount(output + '\n');
 			return;
 		}
 


### PR DESCRIPTION
when we do a full redraw here we don't append an extra newline that regular drawing appends, which puts us 1 line out of sync when we next switch to regular updates we assume that the dynamic output hasn't changed from the pre-redraw render which is a big if