### PR TITLE
Add missing newline in didResize case to match other code path

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -205,11 +205,11 @@ export default class Ink {
 
 		if (didResize) {
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output,
+				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
 			);
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;
-			this.log.updateLineCount(output);
+			this.log.updateLineCount(output + '\n');
 			return;
 		}
 


### PR DESCRIPTION
Apply the same fix to the didResize case as was applied to the output height case. This ensures consistent newline handling in both code paths.