### PR TITLE
Add OSC133 prompt marking support

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -56,7 +56,10 @@ export type Props = {
 	readonly children?: ReactNode;
 
         /**
-          * Whether this text is semantically a prompt.
+         * This property tells Ink to mark any line containing
+         * this text as a prompt using terminal control codes.  Many terminal
+         * emulators have UI affordances for navigating between prompts and
+         * segmenting the scrollback on prompt boundaries.
          */
 	readonly osc133prompt?: boolean;
 };

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -3,6 +3,7 @@ import chalk, {type ForegroundColorName} from 'chalk';
 import {type LiteralUnion} from 'type-fest';
 import colorize from '../colorize.js';
 import {type Styles} from '../styles.js';
+import {type OutputTransformerResult} from '../render-node-to-output.js';
 
 export type Props = {
 	/**
@@ -53,6 +54,11 @@ export type Props = {
 	readonly wrap?: Styles['textWrap'];
 
 	readonly children?: ReactNode;
+
+        /**
+          * Whether this text is semantically a prompt.
+         */
+	readonly osc133prompt?: boolean;
 };
 
 /**
@@ -68,13 +74,14 @@ export default function Text({
 	strikethrough = false,
 	inverse = false,
 	wrap = 'wrap',
+	osc133prompt = false,
 	children,
 }: Props) {
 	if (children === undefined || children === null) {
 		return null;
 	}
 
-	const transform = (children: string): string => {
+	const transform = (children: string): OutputTransformerResult => {
 		if (dimColor) {
 			children = chalk.dim(children);
 		}
@@ -107,7 +114,10 @@ export default function Text({
 			children = chalk.inverse(children);
 		}
 
-		return children;
+		return {
+			line: children,
+			isPrompt: osc133prompt,
+		};
 	};
 
 	return (

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -22,12 +22,19 @@ declare namespace Ink {
 		style?: Except<Styles, 'textWrap'>;
 	};
 
+        export type OutputTransformerResult = {
+                line: string,
+                isPrompt?: boolean,
+                [x: string]: any,
+        } | string;
+
 	type Text = {
 		children?: ReactNode;
 		key?: Key;
 		style?: Styles;
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
-		internal_transform?: (children: string, index: number) => string;
+		internal_transform?: (children: string, index: number) =>
+			OutputTransformerResult;
 	};
 }

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -104,7 +104,7 @@ export default class Ink {
 		this.fullStaticOutput = '';
 
 		// Emit initial OSC 133 prompt start escape
-		if (!isInCi) {
+		if (!isInCi && options.osc133) {
 			options.stdout.write(oscPromptStartRefreshLine);
 		}
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -18,6 +18,17 @@ const isInCi = Boolean(process.env["CI"]);
 
 const noop = () => {};
 
+// OSC133 terminal escapes for marking parts of the output
+// as prompt or command output, as if we were a shell.
+//
+// We need both prompt and command markers: terminal UI affordances
+// use both.  For example, kitty has a command
+// (bound to control-shift-g by default) that displays the last output
+// chunkin a pager.
+//
+// See https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
+// and https://iterm2.com/documentation-escape-codes.html
+
 const oscPromptStartRefreshLine = '\x1b]133;A\x07';
 const oscPromptEnd = '\x1b]133;B\x07';
 const oscCommandStart = '\x1b]133;C\x07';
@@ -194,6 +205,14 @@ export default class Ink {
 			// color on exit.
 			startOscCommand += '\x1b[48;5;52m';
 			endOscCommand = '\x1b[49m' + endOscCommand;
+		}
+
+		// ... CI is not for fun.
+		if (isInCi) {
+			startOscPrompt = '';
+			endOscCommand = '';
+			startOscCommand = '';
+			endOscCommand = '';
 		}
 
 		// For render() output purposes, we assume we're in command mode,

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -15,6 +15,7 @@ import App from './components/App.js';
 import Yoga from 'yoga-wasm-web/auto';
 
 const isInCi = Boolean(process.env["CI"]);
+const isTTY = process.stdout.isTTY;
 
 const noop = () => {};
 
@@ -201,12 +202,12 @@ export default class Ink {
 		// Ask terminal emulators not to redraw the framebuffer
 		// while we're in the middle of a atomic update.  Avoids flicker.
 		try {
-			if (!isInCi) {
+			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateStart);
 			}
 			this.onRenderInternal(didResize);
 		} finally {
-			if (!isInCi) {
+			if (!isInCi && isTTY) {
 				this.options.stdout.write(atomicUpdateEnd);
 			}
 		}
@@ -231,7 +232,7 @@ export default class Ink {
 		let startOscCommand: string;
 		let endOscCommand: string;
 
-		if (isInCi || !this.options.osc133) {
+		if (isInCi || !isTTY || !this.options.osc133) {
 			startOscPrompt = '';
 			endOscPrompt = '';
 			startOscCommand = '';
@@ -244,7 +245,7 @@ export default class Ink {
 		}
 
 		// Colors make everything more fun.
-		if (this.options.debug) {
+		if (this.options.debug && isTTY) {
 			// Dark blue is for prompt mode.  Exiting prompt
 			// mode resets the background color.
 			startOscPrompt += '\x1b[48;5;17m';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -48,6 +48,7 @@ export type Options = {
 	patchConsole: boolean;
 	waitUntilExit?: () => Promise<void>;
 	onFlicker?: () => unknown;
+	osc133?: boolean;
 };
 
 const stripPrefixIfPresent = (prefix: string, s: string): string => {
@@ -198,10 +199,22 @@ export default class Ink {
 		// support the more flexible oscPromptStart; the Output class has
 		// logic for making sure that we send oscPromptStartRefreshLine only
 		// at the start of the line, where it won't move cursor.
-		let startOscPrompt = oscPromptStartRefreshLine;
-		let endOscPrompt = oscPromptEnd;
-		let startOscCommand = oscCommandStart;
-		let endOscCommand = oscCommandEnd;
+		let startOscPrompt: string;
+		let endOscPrompt: string;
+		let startOscCommand: string;
+		let endOscCommand: string;
+
+		if (isInCi || !this.options.osc133) {
+			startOscPrompt = '';
+			endOscPrompt = '';
+			startOscCommand = '';
+			endOscCommand = '';
+		} else {
+			startOscPrompt = oscPromptStartRefreshLine;
+			endOscPrompt = oscPromptEnd;
+			startOscCommand = oscCommandStart;
+			endOscCommand = oscCommandEnd;
+		}
 
 		// Colors make everything more fun.
 		if (this.options.debug) {
@@ -214,14 +227,6 @@ export default class Ink {
 			// color on exit.
 			startOscCommand += '\x1b[48;5;52m';
 			endOscCommand = '\x1b[49m' + endOscCommand;
-		}
-
-		// ... CI is not for fun.
-		if (isInCi) {
-			startOscPrompt = '';
-			endOscCommand = '';
-			startOscCommand = '';
-			endOscCommand = '';
 		}
 
 		// For render() output purposes, we assume we're in command mode,

--- a/src/output.ts
+++ b/src/output.ts
@@ -64,8 +64,7 @@ export default class Output {
 
 	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
-		// Sometimes we get bogus heights like 8.529591648468016e-40
-		this.height = height < 1 ? 0 : height;
+		this.height = height;
 		this.startOscPrompt = startOscPrompt || '';
 		this.endOscPrompt = endOscPrompt || '';
 	}
@@ -105,10 +104,10 @@ export default class Output {
 	}
 
 	get(): {output: string; height: number} {
-		// Initialize output array with a specific set of rows
 		const output: StyledChar[][] = [];
-		// Create local array to track prompt lines for this render
-		const isPromptLine = new Array(this.height).fill(false);
+		// Per-line flag indicating whether any widget on that line
+		// is a prompt.
+		const isPromptLine: boolean[] = [];
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];
@@ -123,6 +122,7 @@ export default class Output {
 			}
 
 			output.push(row);
+			isPromptLine.push(false);
 		}
 
 		const clips: Clip[] = [];

--- a/src/output.ts
+++ b/src/output.ts
@@ -21,6 +21,8 @@ import stringWidth from 'string-width';
 type Options = {
 	width: number;
 	height: number;
+	startOscPrompt?: string;
+	endOscPrompt?: string;
 };
 
 type Operation = WriteOperation | ClipOperation | UnclipOperation;
@@ -52,18 +54,19 @@ type UnclipOperation = {
 export default class Output {
 	width: number;
 	height: number;
+	startOscPrompt: string;
+	endOscPrompt: string;
 
 	private readonly operations: Operation[] = [];
 
 	private charCache: {[line: string]: StyledChar[]} = {};
-	private styledCharsToStringCache: {[serializedStyledChars: string]: string} =
-		{};
+	private styledCharsToStringCache: {[serializedStyledChars: string]: string} = {};
 
-	constructor(options: Options) {
-		const {width, height} = options;
-
+	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
 		this.height = height;
+		this.startOscPrompt = startOscPrompt ?? '!!!!<!!!!';
+		this.endOscPrompt = endOscPrompt ?? '!!!!>!!!!';
 	}
 
 	write(
@@ -101,8 +104,10 @@ export default class Output {
 	}
 
 	get(): {output: string; height: number} {
-		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
+		// Initialize output array with a specific set of rows
 		const output: StyledChar[][] = [];
+		// Create local array to track prompt lines for this render
+		const isPromptLine = new Array(this.height).fill(false);
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];
@@ -192,15 +197,23 @@ export default class Output {
 				let offsetY = 0;
 
 				for (let [index, line] of lines.entries()) {
-					const currentLine = output[y + offsetY];
+					const currentY = y + offsetY;
+					const currentLine = output[currentY];
 
-					// Line can be missing if `text` is taller than height of pre-initialized `this.output`
+					// Line can be missing if `text` is taller than height of pre-initialized output
 					if (!currentLine) {
 						continue;
 					}
 
 					for (const transformer of transformers) {
-						line = transformer(line, index);
+						let result = transformer(line, index);
+                                                if (typeof result == 'string') {
+                                                        result = {line: result};
+                                                }
+
+                                                if (result?.isPrompt) {
+                                                        isPromptLine[currentY] = true;
+                                                }
 					}
 
 					if (!this.charCache.hasOwnProperty(line)) {
@@ -235,22 +248,61 @@ export default class Output {
 			}
 		}
 
-		const generatedOutput = output
-			.map(line => {
-				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
-				const lineWithoutEmptyItems = line.filter(item => item !== undefined);
+		// Group lines by isPrompt to add OSC control sequences at boundaries
+		let currentIsPrompt = false;
+		let result = '';
 
-				const key = JSON.stringify(lineWithoutEmptyItems);
-				if (!this.styledCharsToStringCache.hasOwnProperty(key)) {
-					const result = styledCharsToString(lineWithoutEmptyItems).trimEnd();
-					this.styledCharsToStringCache[key] = result;
-				}
-				return this.styledCharsToStringCache[key];
-			})
-			.join('\n');
+		// Process output lines and add OSC prompt markers at group boundaries
+		for (let i = 0; i < output.length; i++) {
+			const line = output[i]!;
+
+			// Skip empty lines at the end
+			if (i === output.length - 1 && line.every(char => char.value === ' ')) {
+				continue;
+			}
+
+			// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
+			const lineWithoutEmptyItems = line.filter(item => item !== undefined);
+
+			const key = JSON.stringify(lineWithoutEmptyItems);
+			if (!this.styledCharsToStringCache.hasOwnProperty(key)) {
+				const result = styledCharsToString(lineWithoutEmptyItems).trimEnd();
+				this.styledCharsToStringCache[key] = result;
+			}
+
+			const lineText = this.styledCharsToStringCache[key];
+
+			// Use our local tracking array
+			const isPromptLineValue = isPromptLine[i];
+
+			// Add prompt start marker at group boundaries
+			if (!currentIsPrompt && isPromptLineValue) {
+				result += this.startOscPrompt;
+				currentIsPrompt = true;
+			}
+
+			// Add prompt end marker at group boundaries
+			if (currentIsPrompt && !isPromptLineValue) {
+				result += this.endOscPrompt;
+				currentIsPrompt = false;
+			}
+
+			// Add the line
+			result += lineText;
+
+			// Add newline if not the last line
+			if (i < output.length - 1) {
+				result += '\n';
+			}
+		}
+
+		// Ensure prompt is closed at the end if needed
+		if (currentIsPrompt) {
+			result += this.endOscPrompt;
+		}
 
 		return {
-			output: generatedOutput,
+			output: result,
 			height: output.length,
 		};
 	}

--- a/src/output.ts
+++ b/src/output.ts
@@ -215,6 +215,8 @@ export default class Output {
                                                 if (result?.isPrompt) {
                                                         isPromptLine[currentY] = true;
                                                 }
+
+						line = result.line;
 					}
 
 					if (!this.charCache.hasOwnProperty(line)) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -64,9 +64,10 @@ export default class Output {
 
 	constructor({width, height, startOscPrompt, endOscPrompt}: Options) {
 		this.width = width;
-		this.height = height;
-		this.startOscPrompt = startOscPrompt ?? '!!!!<!!!!';
-		this.endOscPrompt = endOscPrompt ?? '!!!!>!!!!';
+		// Sometimes we get bogus heights like 8.529591648468016e-40
+		this.height = height < 1 ? 0 : height;
+		this.startOscPrompt = startOscPrompt || '';
+		this.endOscPrompt = endOscPrompt || '';
 	}
 
 	write(

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -26,7 +26,13 @@ const applyPaddingToText = (node: DOMElement, text: string): string => {
 	return text;
 };
 
-export type OutputTransformer = (s: string, index: number) => string;
+export type OutputTransformerResult = {
+        line: string,
+        isPrompt?: boolean,
+        [x: string]: any,
+} | string;
+
+export type OutputTransformer = (s: string, index: number) => OutputTransformerResult;
 
 // After nodes are laid out, render each to output object, which later gets rendered to terminal
 const renderNodeToOutput = (

--- a/src/render.ts
+++ b/src/render.ts
@@ -46,6 +46,12 @@ export type RenderOptions = {
 	 * Callback for when Ink re-renders the scrollback.
 	 */
 	onFlicker?: () => unknown;
+
+	/**
+	  * Whether to use OSC133 escape sequences for the terminal
+	  * to mark prompt regions.
+	  */
+	osc133?: boolean;
 };
 
 export type Instance = {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -8,11 +8,15 @@ type Result = {
 	staticOutput: string;
 };
 
-const renderer = (node: DOMElement): Result => {
+const renderer = (node: DOMElement,
+		  startOscPrompt: string,
+		  endOscPrompt: string): Result => {
 	if (node.yogaNode) {
 		const output = new Output({
 			width: node.yogaNode.getComputedWidth(),
 			height: node.yogaNode.getComputedHeight(),
+			startOscPrompt: startOscPrompt,
+			endOscPrompt: endOscPrompt,
 		});
 
 		renderNodeToOutput(node, output, {skipStaticElements: true});
@@ -23,6 +27,8 @@ const renderer = (node: DOMElement): Result => {
 			staticOutput = new Output({
 				width: node.staticNode.yogaNode.getComputedWidth(),
 				height: node.staticNode.yogaNode.getComputedHeight(),
+				startOscPrompt: startOscPrompt,
+				endOscPrompt: endOscPrompt,
 			});
 
 			renderNodeToOutput(node.staticNode, staticOutput, {

--- a/src/squash-text-nodes.ts
+++ b/src/squash-text-nodes.ts
@@ -30,11 +30,17 @@ const squashTextNodes = (node: DOMElement): string => {
 
 			// Since these text nodes are being concatenated, `Output` instance won't be able to
 			// apply children transform, so we have to do it manually here for each text node
+			// We can throw away any metadata the transformer returns since we're not using
+			// the result of this function alone for rendering.
 			if (
 				nodeText.length > 0 &&
 				typeof childNode.internal_transform === 'function'
 			) {
-				nodeText = childNode.internal_transform(nodeText, index);
+                                let result = childNode.internal_transform(nodeText, index);
+                                if (typeof result == 'string') {
+                                        result = {line: result};
+                                }
+				nodeText = result.line;
 			}
 		}
 


### PR DESCRIPTION
This change teaches terminal emulators to understand the logical flow of REPL-ish Ink-based-app sessions by (a)busing OSC133 prompt and command output markers: we make the entire non-static UI a giant OSC133 "prompt" and each block of static output an OSC133 "command output".

This way, in terminal emulators that support the
feature (e.g. iTerm2), these markers allow users to click specific conversation turns to highlight them, use keyboard shortcuts to scroll between them, and so on, just as users can in the shell.

Terminal emulators that don't support OSC133 just ignore our marker sequences.

See https://iterm2.com/documentation-escape-codes.html

Test: start the program under iTerm2 and click the outputs.