### PR TITLE
Bracketed paste

### DIFF
--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
-import parseKeypress, {nonAlphanumericKeys} from '../parse-keypress.js';
+import {nonAlphanumericKeys} from '../parse-keypress.js';
+import type {ParsedKey} from '../parse-keypress.js';
 import reconciler from '../reconciler.js';
 import useStdin from './use-stdin.js';
 
@@ -151,11 +152,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 			return;
 		}
 
-		const handleData = (data: string) => {
-			const keypress = parseKeypress(data);
-
-			keypress.name;
-
+		const handleData = (keypress: ParsedKey) => {
 			const key = {
 				upArrow: keypress.name === 'up',
 				downArrow: keypress.name === 'down',


### PR DESCRIPTION
This change should fix the various paste robustness issues we've been having. It makes ink act like other terminal programs. Now, we use a robust terminal handshake for receiving pasted content from terminal emulators and no longer relies on precise write(2) batching (which was never contractual and therefore only accidentally correct) for functionality.